### PR TITLE
修复时间选择器错误和预览code样式错误问题

### DIFF
--- a/client/src/components/editors/HDateEditor.vue
+++ b/client/src/components/editors/HDateEditor.vue
@@ -14,8 +14,11 @@ const emits = defineEmits<{
 const { classNames } = createClassNames("h-date-editor")
 const vars = useThemeVars()
 const text = computed(() =>
-  props.date ? props.date.format("YYYY-MM-DD hh:mm:ss") : "未指定数据"
+  props.date ? props.date.format("YYYY-MM-DD HH:mm:ss") : "未指定数据"
 )
+const onPickDate = (date: Dayjs | null) => {
+  emits('update:date', date);
+}
 </script>
 <template>
   <div :class="classNames" class="px-4">
@@ -27,7 +30,7 @@ const text = computed(() =>
       </div>
       <HDatePicker
         :date="props.date"
-        @update:date="(v) => emits('update:date', v)"
+        @update:date="onPickDate"
       />
     </div>
   </div>

--- a/client/src/components/viewer/HViewerContent.vue
+++ b/client/src/components/viewer/HViewerContent.vue
@@ -243,6 +243,7 @@ $line-numbers
     code
       background: none
       text-shadow: none
+      margin: 0
       padding: 0
   .highlight
     @extend $code-block

--- a/client/src/pages/edit/[type]/[source].vue
+++ b/client/src/pages/edit/[type]/[source].vue
@@ -172,10 +172,10 @@ const updateLayout = (layout: string = "") => {
   updateFromObj({ layout })
 }
 const updateDate = (date: Dayjs | null) => {
-  updateFromObj({ date: date?.format("YYYY-MM-DD hh:mm:ss") })
+  updateFromObj({ date: date?.format("YYYY-MM-DD HH:mm:ss") })
 }
 const updateUpdated = (updated: Dayjs | null) => {
-  updateFromObj({ updated: updated?.format("YYYY-MM-DD hh:mm:ss") })
+  updateFromObj({ updated: updated?.format("YYYY-MM-DD HH:mm:ss") })
 }
 const updateFm = (fm: { [key: string]: unknown }) => {
   updateFromObj({ fm })


### PR DESCRIPTION
1. 将时间选择成功后的时间格式化改为24小时
2. 移除预览中code标签的margin，避免首行向内缩进的显示错误