### PR TITLE
Fix the issue of inconsistent preview time

### DIFF
--- a/client/src/components/editors/HDateEditor.vue
+++ b/client/src/components/editors/HDateEditor.vue
@@ -4,6 +4,7 @@ import { computed } from "vue"
 import { createClassNames } from "~/utils/create-classnames"
 import { HDatePicker } from "@/ui/date-picker"
 import { useThemeVars } from "@/ui/theme"
+import { DATE_FORMAT } from "~/constants";
 
 const props = defineProps<{
   date: Dayjs | null
@@ -14,7 +15,7 @@ const emits = defineEmits<{
 const { classNames } = createClassNames("h-date-editor")
 const vars = useThemeVars()
 const text = computed(() =>
-  props.date ? props.date.format("YYYY-MM-DD HH:mm:ss") : "未指定数据"
+  props.date ? props.date.format(DATE_FORMAT) : "未指定数据"
 )
 const onPickDate = (date: Dayjs | null) => {
   emits('update:date', date);

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -1,1 +1,1 @@
-export const DATE_FORMAT = "YYYY-MM-DD hh:mm:ss"
+export const DATE_FORMAT = "YYYY-MM-DD HH:mm:ss"

--- a/client/src/pages/edit/[type]/[source].vue
+++ b/client/src/pages/edit/[type]/[source].vue
@@ -27,6 +27,7 @@ import HHeaderEditor from "@/editors/HHeaderEditor.vue"
 import HLayoutEditor from "@/editors/HLayoutEditor.vue"
 import HTagEditor from "@/editors/HTagEditor.vue"
 import HNavTitle from "@/ui/nav-list/src/HNavTitle.vue"
+import { DATE_FORMAT } from "~/constants";
 
 const [HMonacoEditor, monacoLoading] = useAsyncComponentWithLoading(
   () => import("@/editors/HMonacoEditor.vue")
@@ -172,10 +173,10 @@ const updateLayout = (layout: string = "") => {
   updateFromObj({ layout })
 }
 const updateDate = (date: Dayjs | null) => {
-  updateFromObj({ date: date?.format("YYYY-MM-DD HH:mm:ss") })
+  updateFromObj({ date: date?.format(DATE_FORMAT) })
 }
 const updateUpdated = (updated: Dayjs | null) => {
-  updateFromObj({ updated: updated?.format("YYYY-MM-DD HH:mm:ss") })
+  updateFromObj({ updated: updated?.format(DATE_FORMAT) })
 }
 const updateFm = (fm: { [key: string]: unknown }) => {
   updateFromObj({ fm })


### PR DESCRIPTION
fix #29 
The issue was caused by a previous omission in the modification of time due to improper use of global constants. Therefore, I have replaced all instances using the same format with constants and fixed the issue.